### PR TITLE
Move eslint-config-ember to dependencies

### DIFF
--- a/blueprints/ember-cli-eslint/index.js
+++ b/blueprints/ember-cli-eslint/index.js
@@ -5,13 +5,5 @@ module.exports = {
     // this prevents an error when the entityName is
     // not specified (since that doesn't actually matter
     // to us
-  },
-
-  afterInstall: function () {
-    return this.addPackageToProject('eslint-config-ember', '^0.3.0');
-  },
-
-  afterUninstall: function () {
-    return this.removePackageFromProject('eslint-config-ember');
-  },
+  }
 };

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "ember-load-initializers": "^0.5.0",
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.1.2",
-    "eslint-config-ember": "^0.3.0",
     "express": "^4.12.3",
     "loader.js": "^4.0.0",
     "phantomjs": "^2.1.3"
@@ -52,6 +51,7 @@
   "dependencies": {
     "broccoli-lint-eslint": "^2.0.0",
     "ember-cli-babel": "^5.1.5",
+    "eslint-config-ember": "^0.3.0",
     "js-string-escape": "^1.0.0"
   },
   "keywords": [


### PR DESCRIPTION
When listed as a `devDependency`, I noticed that the application that had `ember-cli-eslint` installed also needed `eslint-config-ember` within its own dependencies.  By moving it to be a `dependency` of the addon instead, that could be avoided, which makes this addon a little easier to manage, since you don't have to adjust the version of `eslint-config-ember` directly.