### PR TITLE
Use babel-eslint from broccoli-lint-eslint

### DIFF
--- a/config/eslint-tests.js
+++ b/config/eslint-tests.js
@@ -1,8 +1,10 @@
 'use strict';
 
 module.exports = {
-  "extends": "ember",
-  "parser": "babel-eslint",
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module"
+  },
   "rules": {
     "arrow-spacing": 0,
     "prefer-arrow-callback": 0,
@@ -13,6 +15,6 @@ module.exports = {
     "arrow-spacing": 0,
     "array-callback-return": 0,
     "no-empty-function": 0,
-    "prefer-rest-params": 0    
+    "prefer-rest-params": 0
   }
 };

--- a/config/eslint.js
+++ b/config/eslint.js
@@ -1,10 +1,10 @@
 'use strict';
 
 module.exports = {
-  "extends": "ember",
-  "parser": "babel-eslint",
-  "env": {
-    "es6": true
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module"
   },
   "rules": {
     "prefer-arrow-callback": 0,

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 'use strict';
+var path = require('path');
+var resolve = require('resolve');
 var eslint = require('broccoli-lint-eslint');
 var jsStringEscape = require('js-string-escape');
 
@@ -15,20 +17,29 @@ module.exports = {
     this.options = app.options.eslint || {};
   },
 
-  lintTree: function(type, tree) {
+  lintTree: function(type, node) {
     var project = this.project;
 
     if (type === 'templates') {
       return;
     }
 
-    return eslint(tree, {
+    var broccolLintESLintRoot = path.dirname(resolve.sync('broccoli-lint-eslint'));
+    var babelESLintDir = path.dirname(resolve.sync('babel-eslint', { basedir: broccolLintESLintRoot }));
+
+    return eslint(node, {
+
+      // Find broccoli-lint-eslint's babel-eslint parser and use it as our default
+      options: {
+        parser: babelESLintDir
+      },
+
       testGenerator: this.options.testGenerator || function(relativePath, errors) {
         if (!project.generateTestFile) {
           // Empty test generator. The reason we do that is that `lintTree`
-          // will merge the returned tree with the `tests` directory anyway,
+          // will merge the returned node with the `tests` directory anyway,
           // so we minimize the damage by returning empty files instead of
-          // duplicating app tree.
+          // duplicating app node.
           return '';
         }
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "eslint-config-ember": "^0.3.0",
     "express": "^4.12.3",
     "loader.js": "^4.0.0",
-    "phantomjs": "^2.1.3"
+    "phantomjs": "^2.1.3",
+    "resolve": "^1.1.7"
   },
   "dependencies": {
     "broccoli-lint-eslint": "^2.0.0",

--- a/tests/dummy/app/controllers/.eslintrc
+++ b/tests/dummy/app/controllers/.eslintrc
@@ -1,5 +1,9 @@
 {
-  "extends": "ember",
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module"
+  },
   "rules": {
     "no-undef": 0
   }


### PR DESCRIPTION
Inspired by @alexlafroscia's and @mmun's suggestions in https://github.com/ember-cli/ember-cli-eslint/pull/53, I went about refactoring the `lint-tree` hook inside of `index.js` to specify `babel-eslint` as a parser option by resolving its path directly from `broccoli-lint-eslint`. 

Naturally, this would require including `babel-eslint` as a dependency in `broccoli-lint-eslint` -- I can get a PR out for that soon as well. I'll also update our documentation as part of this PR to better explain the relationship that `babel-eslint` has with `ember-cli-eslint`. 