### PR TITLE
Document Disabling JSHint

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,34 @@ After installing, simply add the following option to your `eslint` configuration
     "parser": "babel-eslint",
 ```
 
+## Disabling JSHint
+Congratulations! You've made the leap into the next generation of JavaScript linting. At the moment, however, `ember-cli` defaults to generating applications and addons with a `jshint` configuration, and so you may initially notice the two awkwardly running side by side. Here are a few tips for handling this:
+
+#### ember-cli >= 2.5.0
+As of `ember-cli v.2.5.0`, [`jshint` is provided through its own `ember-cli-jshint` addon](https://github.com/ember-cli/ember-cli/pull/5757). Running `npm uninstall --save-dev ember-cli-jshint`, in addition to removing any `.jshintrc` files from your project should guarantee that its behavior is disabled.
+
+#### ember-cli < 2.5.0
+Controlling linting is a bit trickier on versions of `ember-cli` prior to `2.5.0`. Within your `ember-cli-build.js` file, `ember-cli-qunit` or `ember-cli-mocha` can be configured to have their default linting process disabled during:
+
+```javascript
+'ember-cli-qunit': {
+  useLintTree: false
+}
+```
+or
+```javascript
+'ember-cli-mocha': {
+  useLintTree: false
+}
+```
+Alongside this setting, the `hinting` property can then be used to enable/disable globally:
+
+```javascript
+hinting: !isTesting,  
+```
+
+
+
 ## Installation
 
 * `ember install ember-cli-eslint`

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Alongside this setting, the `hinting` property can then be used to enable/disabl
 ```javascript
 hinting: !isTesting,  
 ```
-
+Furthermore, a `.eslintignore` file can be used to exclude files from linting while the linter is running. Its syntax is identical to `.gitignore` files.
 
 
 ## Installation


### PR DESCRIPTION
`ember-cli-2.5.0` made disabling JSHint and using ESLint [fantastically easier](https://github.com/ember-cli/ember-cli/pull/5757). Now, though, having a few projects ahead and behind 2.5 that are all using `ember-cli-eslint`, I realized that it would be really useful to document the strategies from both eras. 

Would anyone mind a quick proofread to make sure everything is correct? (cc: 
@rwjblue @Turbo87 @alexlafroscia) 

Possibly helpful:
* https://github.com/ember-cli/ember-cli-eslint/issues/7
* https://github.com/ember-cli/ember-cli-eslint/issues/57