### PR TITLE
Remove phantomJS from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "ember-try": "^0.1.2",
     "eslint-config-ember": "^0.3.0",
     "express": "^4.12.3",
-    "loader.js": "^4.0.0",
-    "phantomjs": "^2.1.3"
+    "loader.js": "^4.0.0"
   },
   "dependencies": {
     "broccoli-lint-eslint": "^2.0.0",


### PR DESCRIPTION
Since Ember's universal [recommendation](https://guides.emberjs.com/v2.5.0/getting-started/#toc_phantomjs-optional) is for users to have PhantomJS installed globally on their machines -- should they choose to use it at all -- it seems out of place for us to be requiring in our `devDepencencies`. 

Install-time slowdowns not even withstanding, it seems like doing this is only risking creating unexpected behaviors by going against most other Ember addons and applications out there. 