### PR TITLE
Use path.join for relative path resolution

### DIFF
--- a/blueprints/ember-cli-eslint/files/.eslintrc.js
+++ b/blueprints/ember-cli-eslint/files/.eslintrc.js
@@ -1,3 +1,7 @@
+var path = require('path');
+
 module.exports = {
-  extends: './node_modules/ember-cli-eslint/coding-standard/ember-application.js'
+  extends: [
+    path.join(__dirname, 'node_modules/ember-cli-eslint/coding-standard/ember-application.js')
+  ]
 };

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
 
   // TODO: Disable this (or set it to return false) before committing
   isDevelopingAddon: function() {
-    return false
+    return false;
   },
 
   // instructs ember-cli-qunit and ember-cli-mocha to


### PR DESCRIPTION
With the way `.eslintrc.js` tries to extend from `./node_modules/ember-cli-eslint/coding-standard/ember-application.js`, I'm getting resolution errors stemming from the fact that eslint is being run from within ember-cli-eslint.

When serving after generating a new app and installing `ember-cli-eslint`:
```
The Broccoli Plugin: [EslintValidationFilter] failed with:
Error: Cannot read config file: /Users/bsipple/fooApp/node_modules/node_modules/ember-cli-eslint/coding-standard/ember-application.js
Error: Cannot find module '/Users/bsipple/fooApp/node_modules/node_modules/ember-cli-eslint/coding-standard/ember-application.js'
Referenced from: /Users/bsipple/fooApp/.eslintrc.js
```
I'm not sure why I didn't see this when developing the change -- I might have had `eslint` installed locally -- but regardless, we can overcome this just by adding `path.join` to the mix:
```
var path = require('path');

module.exports = {
  extends: [
    path.join(__dirname, 'node_modules/ember-cli-eslint/coding-standard/ember-application.js')
  ]
};
```
 (That said, I'd still like to know that I'm not alone in seeing this.)
