### PR TITLE
Add `ember lint` command

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
+/*eslint-env node*/
+
 'use strict';
+
 var eslint = require('broccoli-lint-eslint');
 var jsStringEscape = require('js-string-escape');
 
@@ -18,6 +21,10 @@ module.exports = {
     this._super.included.apply(this, arguments);
     this.jshintrc = app.options.jshintrc;
     this.options = app.options.eslint || {};
+  },
+
+  includedCommands: function() {
+    return require('./lib/commands');
   },
 
   lintTree: function(type, tree) {

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,0 +1,7 @@
+/*eslint-env node*/
+
+'use strict';
+
+module.exports = {
+  'lint': require('./lint')
+};

--- a/lib/commands/lint.js
+++ b/lib/commands/lint.js
@@ -1,0 +1,11 @@
+/*eslint-env node*/
+
+'use strict';
+
+module.exports = {
+  name: 'lint',
+  description: 'Run ESLint on your Ember app',
+  works: 'insideProject',
+
+  run: require('../tasks/lint')
+};

--- a/lib/tasks/lint.js
+++ b/lib/tasks/lint.js
@@ -3,10 +3,14 @@
 'use strict';
 
 var Builder = require('broccoli').Builder;
+var reject = require('rsvp').reject;
 var Funnel = require('broccoli-funnel');
 var eslint = require('broccoli-lint-eslint');
 
 function runLint() {
+  var ui = this.ui;
+  var hadError = false;
+
   var tree = new Funnel(this.project.root, {
     include: [
       'app/**/*.js',
@@ -14,11 +18,24 @@ function runLint() {
     ]
   });
   var eslintTree = eslint(tree, {
-    throwOnError: true
+    console: {
+      log: function(message) {
+        hadError = true;
+        ui.writeLine(message);
+      },
+      error: function(message) {
+        hadError = true;
+        ui.writeLine(message, 'ERROR');
+      }
+    }
   });
   var builder = new Builder(eslintTree);
 
-  return builder.build();
+  return builder.build().then(function() {
+    if (hadError) {
+      return reject();
+    }
+  });
 }
 
 module.exports = runLint;

--- a/lib/tasks/lint.js
+++ b/lib/tasks/lint.js
@@ -1,0 +1,24 @@
+/*eslint-env node*/
+
+'use strict';
+
+var Builder = require('broccoli').Builder;
+var Funnel = require('broccoli-funnel');
+var eslint = require('broccoli-lint-eslint');
+
+function runLint() {
+  var tree = new Funnel(this.project.root, {
+    include: [
+      'app/**/*.js',
+      'tests/**/*.js'
+    ]
+  });
+  var eslintTree = eslint(tree, {
+    throwOnError: true
+  });
+  var builder = new Builder(eslintTree);
+
+  return builder.build();
+}
+
+module.exports = runLint;

--- a/lib/tasks/lint.js
+++ b/lib/tasks/lint.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var Builder = require('broccoli').Builder;
+var Builder = require('broccoli-builder').Builder;
 var reject = require('rsvp').reject;
 var Funnel = require('broccoli-funnel');
 var eslint = require('broccoli-lint-eslint');
@@ -13,6 +13,7 @@ function runLint() {
 
   var tree = new Funnel(this.project.root, {
     include: [
+      'addon/**/*.js',
       'app/**/*.js',
       'tests/**/*.js'
     ]

--- a/lib/tasks/lint.js
+++ b/lib/tasks/lint.js
@@ -21,7 +21,6 @@ function runLint() {
   var eslintTree = eslint(tree, {
     console: {
       log: function(message) {
-        hadError = true;
         ui.writeLine(message);
       },
       error: function(message) {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "testdouble": "^1.6.0"
   },
   "dependencies": {
+    "broccoli": "^0.16.9",
+    "broccoli-funnel": "^1.0.6",
     "broccoli-lint-eslint": "^2.0.0",
     "ember-cli-babel": "^5.1.6",
     "js-string-escape": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "testdouble": "^1.6.0"
   },
   "dependencies": {
-    "broccoli": "^0.16.9",
+    "broccoli-builder": "^0.18.0",
     "broccoli-funnel": "^1.0.6",
     "broccoli-lint-eslint": "^2.0.0",
     "ember-cli-babel": "^5.1.6",


### PR DESCRIPTION
`ember lint` run `eslint` on the `app` and `tests` directories.

The only issue right now is that the output of the ESLint command is grabbed from the `STDOUT` of the child process and then passed through to the output of the Ember process, so we lose the original colors.  I would love to maintain them, but I'm just not sure how.  I'd love a pointer in the right direction!

Also, I used `Promise` in the new task; I'm guessing that won't be a problem but if I should write that another way, I'm happy to.

Closes #92 
