### PR TITLE
Resolve Ember Testing coding standard

### DIFF
--- a/blueprints/ember-cli-eslint/files/.eslintrc.js
+++ b/blueprints/ember-cli-eslint/files/.eslintrc.js
@@ -1,7 +1,5 @@
-var path = require('path');
-
 module.exports = {
   extends: [
-    require.resolve('ember-cli-eslint/coding-standard/ember-application.js')
+    require.resolve('ember-cli-eslint/coding-standard/ember-application')
   ]
 };

--- a/blueprints/ember-cli-eslint/files/tests/.eslintrc.js
+++ b/blueprints/ember-cli-eslint/files/tests/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: '../node_modules/ember-cli-eslint/coding-standard/ember-testing.js'
+  extends: require.resolve('ember-cli-eslint/coding-standard/ember-testing')
 };


### PR DESCRIPTION
According to this [commit](https://github.com/ember-cli/ember-cli-eslint/commit/d1c3c4408f64e07b3ee274a991cab9ee318085b6) I think that `require.resolve` should be used here too.