### PR TITLE
Pass console object that wraps this.ui

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports = {
 
   lintTree: function(type, tree) {
     var project = this.project;
+    var ui = this.ui;
 
     if (type === 'templates') {
       return undefined;
@@ -60,6 +61,16 @@ module.exports = {
           passed: passed,
           errorMessage: relativePath + ' should pass ESLint.' + messages
         }]);
+      },
+
+      console: {
+        log: function(message) {
+          ui.writeLine(message);
+        },
+
+        error: function(message) {
+          ui.writeLine(message, 'ERROR');
+        }
       }
     });
   }


### PR DESCRIPTION
This passes a `console` object in the options object passed to broccoli-lint-eslint (see https://github.com/ember-cli/broccoli-lint-eslint/pull/51).

This means that broccoli-lint-eslint can respect the `--silent` option by using this object over the `console` global.

I was able to test this in a project that uses `ember-cli-eslint` by npm-linking ember-cli-eslint and broccoli-lint-eslint locally:

<img width="711" alt="screen shot 2016-08-06 at 8 41 06 pm" src="https://cloud.githubusercontent.com/assets/15169/17460339/4cd5c734-5c16-11e6-9886-adffe840986b.png">

This should be a non-breaking change, but we may want to co-ordinate this with a version bump in broccoli-lint-eslint.