### PR TITLE
Remove unnecessary `ember-ajax` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
-    "ember-ajax": "2.4.1",
     "ember-cli": "2.6.2",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",


### PR DESCRIPTION
Removes the `ember-ajax` dependency, which we don't need, as @Turbo87 pointed out in #104