### PR TITLE
Remove `babel` as the default parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ ESLinting for Ember CLI apps, [ESLint](http://eslint.org/) provides a scriptable
 ember install ember-cli-eslint
 ```
 
-This will create a `.eslintrc.js` file in the root of your project, and another `.eslintrc.js` file inside of `/test`. These files extend from our recommended configurations for [Ember application code](/coding-standard/ember-application.js) and [Ember testing code](/coding-standard/ember-testing.js), respectively. However, starting from scratch is as easy as deleting the `extends` declaration and [writing your own configuration rules as usual](http://eslint.org/docs/user-guide/configuring).
+After installation, an `.eslintrc.js` file will be placed in both the root of your project and the `/tests` directory.
 
 ## Disabling JSHint
+
 Congratulations! You've made the leap into the next generation of JavaScript linting. At the moment, however, `ember-cli` defaults to generating applications and addons with a `jshint` configuration, and so you may initially notice the two awkwardly running side by side. Here are a few tips for handling this:
 
 #### ember-cli >= 2.5.0

--- a/blueprints/ember-cli-eslint/files/.eslintrc.js
+++ b/blueprints/ember-cli-eslint/files/.eslintrc.js
@@ -1,5 +1,13 @@
 module.exports = {
-  extends: [
-    require.resolve('ember-cli-eslint/coding-standard/ember-application')
-  ]
+  root: true,
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module'
+  },
+  extends: 'eslint:recommended',
+  env: {
+    'browser': true
+  },
+  rules: {
+  }
 };

--- a/blueprints/ember-cli-eslint/files/tests/.eslintrc.js
+++ b/blueprints/ember-cli-eslint/files/tests/.eslintrc.js
@@ -1,3 +1,5 @@
 module.exports = {
-  extends: require.resolve('ember-cli-eslint/coding-standard/ember-testing')
+  env: {
+    'embertest': true
+  }
 };


### PR DESCRIPTION
*Note:* This is definitely a breaking change that will require a major
version bump and a note in the `CHANGELOG` about the fact that the
`coding-standard` files no longer exist (in case someone is upgrading
and currently extending from them).

Closes #81