### PR TITLE
Pass options to broccoli-lint-eslint

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,8 @@ module.exports = {
         }]);
       },
 
+      options: this.options,
+
       console: {
         log: function(message) {
           ui.writeLine(message);


### PR DESCRIPTION
Hi,

I encountered a problem with eslint today:
- I was using https://github.com/netguru/eslint-plugin-netguru-ember
- One of the rules needed improvement because eslint was yelling in one case when it shouldn't
- I fixed the it, released new version of plugin and updated package in my project
- Eslint from command line worked as expected - no problems
- Eslint called by ember was still showing errors, however when I changed anything in given "wrong" file - it automagically started passing

I found out that there is a setting called `persist` in `broccoli-lint-eslint`. 
Funny thing, documentation says the default value is `false`, but the code clearly shows otherwise.  But straight to the point.. 

In `broccoli-lint-eslint` there is:
https://github.com/ember-cli/broccoli-lint-eslint/blob/bf627753313b0df664c2ef69f71833925d0cfe62/lib/index.js#L102

```
if (typeof this.internalOptions.persist === 'undefined') {
    this.internalOptions.persist = true;
}
```

the `this.internalOptions` contains all the settings that are being passed through `ember-cli-eslint` in (https://github.com/ember-cli/ember-cli-eslint/blob/master/index.js#L32), unfortunately `ember-cli-eslint` doesn't passes settings from `ember-cli-build.js`.

This is really simple PR, that makes sure the settings are passed to `broccoli-lint-eslint` so users can leverage from using settings like `persist` and so on like this:

```
var app = new EmberApp(defaults, {
    eslint: {
      options: {
        persist: false,
      }
    },
  });
```

This PR also sort of a continuation of original Issue: #84 

Looking forward to hearing from you :)
