### PR TITLE
Update project structure for Ember CLI 2.8.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,7 @@
 {
   "name": "ember-cli-eslint",
   "dependencies": {
-    "ember": "~2.6.0",
-    "ember-cli-shims": "0.1.1",
-    "ember-cli-test-loader": "0.2.2",
-    "ember-qunit-notifications": "0.1.0"
+    "ember": "~2.8.0",
+    "ember-cli-shims": "0.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ember-cli-qunit": "^3.0.0",
     "ember-cli-release": "1.0.0-beta.1",
     "ember-cli-sri": "^2.1.0",
+    "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",


### PR DESCRIPTION
Related to #121, update to match relevant changes to the default project structure.