### PR TITLE
Remove quotes from properties in .eslintrc.js files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
   },
   extends: 'eslint:recommended',
   env: {
-    'browser': true
+    browser: true
   },
   rules: {
   }

--- a/blueprints/ember-cli-eslint/files/.eslintrc.js
+++ b/blueprints/ember-cli-eslint/files/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
   },
   extends: 'eslint:recommended',
   env: {
-    'browser': true
+    browser: true
   },
   rules: {
   }

--- a/blueprints/ember-cli-eslint/files/tests/.eslintrc.js
+++ b/blueprints/ember-cli-eslint/files/tests/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
   env: {
-    'embertest': true
+    embertest: true
   }
 };

--- a/tests/dummy/.eslintrc.js
+++ b/tests/dummy/.eslintrc.js
@@ -2,6 +2,6 @@
 
 module.exports = {
   env: {
-    'embertest': true
+    embertest: true
   }
 };


### PR DESCRIPTION
My OCD couldn't help itself 😀. 

I noticed we were being inconsistent with the use of property quotes in our `.eslintrc.js` files, so I standardized everything to no-quotes.

A lot of `.eslintrc.js` files in the wild seem to look this way -- my guess is due to the transition from `.eslintrc.json` a while back -- but FWIW the ESLint team appears to be [writing their `.js`'s quoteless](https://github.com/eslint/eslint/search?l=javascript&p=1&q=rules&type=Code&utf8=%E2%9C%93).