### PR TITLE
Remove ember-cli-babel dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,11 @@
     "chai": "^3.5.0",
     "ember-cli": "2.8.0",
     "ember-cli-app-version": "^2.0.0",
+    "ember-cli-babel": "^6.0.0-beta.7",
     "ember-cli-blueprint-test-helpers": "^0.17.1",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.4.0-beta.2",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-qunit": "^3.0.0",
     "ember-cli-release": "1.0.0-beta.1",
@@ -57,7 +58,6 @@
   },
   "dependencies": {
     "broccoli-lint-eslint": "^3.1.0",
-    "ember-cli-babel": "^5.1.6",
     "js-string-escape": "^1.0.0",
     "rsvp": "^3.2.1",
     "walk-sync": "^0.3.0"


### PR DESCRIPTION
As part of the work for ember-cli@2.13, all "built in" addons are being updated to use ember-cli-babel@6.

In this addons case, we do not need ember-cli-babel at all so removing the dep is simpler/better.