### PR TITLE
Parse ES2017 by default.

### DIFF
--- a/blueprints/ember-cli-eslint/files/.eslintrc.js
+++ b/blueprints/ember-cli-eslint/files/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2017,
     sourceType: 'module'
   },
   extends: 'eslint:recommended',


### PR DESCRIPTION
It is a finalised spec. I don't see reason to not assume code is ES2017 by default. This is trolling people attempting to use async/await.