### PR TITLE
CI: Adjust "yarn install" instruction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - phantomjs --version
 
 install:
-  - yarn install --no-lockfile
+  - yarn install --ignore-engines --no-lockfile --non-interactive
 
 before_deploy:
   - yarn global add auto-dist-tag


### PR DESCRIPTION
This should hopefully fix the CI build, now that Node 8 `== stable`

/cc @rwjblue 