### PR TITLE
Fix using "group" option without a "testGenerator"

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports = {
 
     return ESLint.create(tree, {
       testGenerator: this.options.testGenerator || this._testGenerator,
-      group: (this.options.group !== false) ? type : undefined,
+      group: (this.options.testGenerator && this.options.group !== false) ? type : undefined,
       extensions: this.options.extensions,
 
       options: {


### PR DESCRIPTION
This PR fixes #213, by preventing to set `group` option to `true` if the `testGenerator` option is not set.