### PR TITLE
Extend test framework detection to `ember-qunit` and `ember-mocha`

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ let app = new EmberApp(defaults, {
 });
 ```
 
-- `testGenerator` is automatically detected if `ember-cli-qunit` or
-  `ember-cli-mocha` are used, but can also be set to `qunit` and
-  `mocha` manually.
+- `testGenerator` is automatically detected if `ember-qunit`/`ember-cli-qunit`
+  or `ember-mocha`/`ember-cli-mocha` are used, but can also be set to `qunit`
+  and `mocha` manually.
 
 - `group` can be set to `false` to go back to the previous behavior where
   every generated test was contained in its own separate module.

--- a/index.js
+++ b/index.js
@@ -20,9 +20,9 @@ module.exports = {
     var VersionChecker = require('ember-cli-version-checker');
     var checker = new VersionChecker(this);
 
-    if (checker.for('ember-cli-qunit', 'npm').exists()) {
+    if (checker.for('ember-qunit', 'npm').exists() || checker.for('ember-cli-qunit', 'npm').exists()) {
       this._testGenerator = 'qunit';
-    } else if (checker.for('ember-cli-mocha', 'npm').exists()) {
+    } else if (checker.for('ember-mocha', 'npm').exists() || checker.for('ember-cli-mocha', 'npm').exists()) {
       this._testGenerator = 'mocha';
     }
   },


### PR DESCRIPTION
because https://github.com/emberjs/ember-qunit/pull/282 and https://github.com/emberjs/ember-mocha/pull/173