### PR TITLE
Add throwOnError and throwOnWarn options

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ let app = new EmberApp(defaults, {
     group: true,
     rulesDir: 'eslint-rules',
     extensions: ['js'],
+    throwOnError: true,
+    throwOnWarn: true,
   }
 });
 ```
@@ -145,6 +147,11 @@ let app = new EmberApp(defaults, {
   It defaults to `eslint-rules`.
 
 - `extensions` is an array containing the file extensions to lint. If you want to lint JavaScript and TypeScript files for example it should be set to `['js', 'ts']`. _NOTE_: If you add Typescript files `typescript-eslint-parser` has to be installed and specified as the parser. For more information take a look at the [`typescript-eslint-parser`](https://github.com/eslint/typescript-eslint-parser)
+
+- `throwOnError` can be set to `true` to cause builds to fail on first eslint rule violation with `error`-level severity
+
+- `throwOnWarn` can be set to `true` to cause builds to fail on first eslint rule violation with `warn`-level severity. _NOTE_: Setting this to true will automatically enable `throwOnError` behavior
+
 
 ### On Build Files
 

--- a/index.js
+++ b/index.js
@@ -45,6 +45,8 @@ module.exports = {
       testGenerator: this.options.testGenerator || this._testGenerator,
       group: (this.options.group !== false) ? type : undefined,
       extensions: this.options.extensions,
+      throwOnError: this.options.throwOnError,
+      throwOnWarn: this.options.throwOnWarn,
 
       options: {
         rulesDir: this.options.rulesDir || 'eslint-rules'


### PR DESCRIPTION
I wanted this functionality so I added it.
The only caveat that I found was that this causes the build to fail and hang instead of fail and quit.

An example is: 
![image](https://user-images.githubusercontent.com/452199/37919110-b0670754-312b-11e8-96ca-c74b2bba053d.png)

As you can see the build failed but I wasn't thrown back to Terminal prompt but was instead stuck until I quit the current running process: On Windows with CTRL+C

Is this the wanted behavior or should this be fixed as well?