### PR TITLE
Remove obsolete `es6-promise` dev dependency

### DIFF
--- a/node-tests/test.js
+++ b/node-tests/test.js
@@ -1,6 +1,5 @@
 var fs = require('fs-extra');
 var exec = require('child_process').exec;
-var Promise = require('es6-promise').Promise;
 
 var expect = require('chai').expect;
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.18.0",
-    "es6-promise": "^4.0.0",
     "express": "^4.12.3",
     "fs-extra": "^5.0.0",
     "loader.js": "^4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2627,11 +2627,6 @@ es6-map@^0.1.5:
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
 
-es6-promise@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.0.tgz#dda03ca8f9f89bc597e689842929de7ba8cebdf0"
-  integrity sha1-3aA8qPn4m8WX5omEKSnee6jOvfA=
-
 es6-set@~0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"


### PR DESCRIPTION
Node 6 supports native Promises