### PR TITLE
Fix `VersionChecker` construction

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = {
     this._super.init && this._super.init.apply(this, arguments);
 
     var VersionChecker = require('ember-cli-version-checker');
-    var checker = new VersionChecker(this);
+    var checker = new VersionChecker(this.project);
 
     if (checker.for('ember-qunit', 'npm').exists() || checker.for('ember-cli-qunit', 'npm').exists()) {
       this._testGenerator = 'qunit';


### PR DESCRIPTION
We want to check the `ember-qunit` dependency version of the host app, not of ourselves. This will make the project work with Yarn PnP.

https://github.com/emberjs/ember.js/blob/master/blueprints/test-framework-detector.js#L19 does is similarly, so I guess it's the actually correct way of doing it.