### PR TITLE
Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,17 @@ ember-cli-eslint
 [ember-observer-badge]: https://emberobserver.com/badges/ember-cli-eslint.svg
 [ember-observer-badge-url]: https://emberobserver.com/addons/ember-cli-eslint
 
-[ESLint](http://eslint.org/) for [Ember CLI](https://ember-cli.com/) apps and addons
+[ESLint](http://eslint.org/) for [Ember CLI](https://ember-cli.com/) apps and addons.
 
+## 🔴 DEPRECATED 🔴
+
+Please use [ESLint](https://github.com/eslint/eslint) directly instead.
+
+More info / background:
+
+* https://github.com/ember-cli/rfcs/pull/121
+* https://github.com/emberjs/rfcs/blob/master/text/0121-remove-ember-cli-eslint.md
+* https://github.com/ember-cli/ember-cli/pull/9009
 
 Installation
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Adds as a notice that is the same as the [deprecation notice](https://github.com/ember-template-lint/ember-cli-template-lint/blob/master/README.md) that ember-cli-template-lint has.

I also marked both of these packages as deprecated.

```
npm deprecate ember-cli-template-lint "Call ember-template-lint directly instead: https://github.com/emberjs/rfcs/blob/master/text/0121-remove-ember-cli-eslint.md"
```

```
npm deprecate ember-cli-eslint "Call eslint directly instead: https://github.com/emberjs/rfcs/blob/master/text/0121-remove-ember-cli-eslint.md"
```

More info:

* https://github.com/ember-cli/rfcs/pull/121
* https://github.com/emberjs/rfcs/blob/master/text/0121-remove-ember-cli-eslint.md
* https://github.com/ember-cli/ember-cli/pull/9009